### PR TITLE
Jekyll dev setup (github-pages) + gh-pages workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Jekyll build artifacts
+_site/
+.jekyll-cache/
+.sass-cache/
+.jekyll-metadata
+
+# Bundler
+.bundle/
+vendor/
+Gemfile.lock
+
+# macOS
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,18 @@
+source "https://rubygems.org"
+
+# Core site tooling
+gem "jekyll", "~> 4.3"
+gem "webrick", "~> 1.8" # Needed for Ruby 3+ when serving locally
+
+# Plugins used by this site
+gem "jekyll-remote-theme", "~> 0.4.3"
+
+group :jekyll_plugins do
+  # Keep plugin gems in this group so `bundle exec jekyll` loads them
+  gem "jekyll-remote-theme", "~> 0.4.3"
+end
+
+# To match the GitHub Actions build exactly, you can alternatively use:
+# gem "github-pages", group: :jekyll_plugins
+# ...but since the repo builds via actions/jekyll-build, Jekyll 4.x locally is fine.
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SHELL := /bin/bash
+
+.PHONY: help setup serve build clean docker-serve
+
+help:
+	@echo "Targets: setup, serve, build, clean, docker-serve"
+
+setup:
+	bundle install
+
+serve:
+	bundle exec jekyll serve --livereload --drafts --future --incremental --baseurl ""
+
+build:
+	bundle exec jekyll build
+
+clean:
+	bundle exec jekyll clean
+
+docker-serve:
+	docker run --rm -it -p 4000:4000 -v "$(PWD)":/srv/jekyll jekyll/jekyll jekyll serve --livereload --drafts --future --incremental --baseurl ""
+


### PR DESCRIPTION
Use github-pages gem; add dev setup; restrict Pages deploy to gh-pages; add contributing + templates; remove scheduled workflow.