### PR TITLE
Add repo-local worktree tooling and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Repo-local Git worktrees (do not commit)
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+Agent Worktree Structure
+
+Overview
+- Main branch stays checked out in the repo root (`.`).
+- All other branches live as Git worktrees under `./.worktrees/<branch>`.
+- Directory names replace slashes with dashes (e.g., `feature/foo` -> `.worktrees/feature-foo`).
+
+Why
+- Enables multiple agents/tabs to work concurrently without branch conflicts.
+- Keeps `main` as the canonical working copy at the root for quick reads and simple changes.
+
+Conventions
+- Do not check out `main` in a worktree. Root holds `main`.
+- Create and work on new branches only inside `./.worktrees/`.
+- One branch can only be checked out in one place at a time (Git worktree rule).
+
+Helper Script
+- Use `scripts/worktrees.sh` to manage worktrees consistently.
+
+Branch Naming
+- Prefer using hyphens or dots in branch names (e.g., `feature.foo` or `feature-foo`) for clearer 1:1 mapping to worktree folder names.
+- Slashes in branch names (e.g., `feature/foo`) are fine and conventional; just note that worktree folders are flattened (slashes become dashes) to avoid nested dirs.
+- Use `scripts/worktrees.sh path <branch>` to get the exact folder path regardless of naming.
+
+Common Tasks
+- List worktrees: `scripts/worktrees.sh list`
+- Create a new feature branch from `main` and add a worktree:
+  - `scripts/worktrees.sh create feature/foo --base main`
+  - `cd $(scripts/worktrees.sh path feature/foo)`
+- Add a worktree for an existing branch:
+  - `scripts/worktrees.sh add gh-pages`
+  - `cd $(scripts/worktrees.sh path gh-pages)`
+- Remove a worktree when done:
+  - `scripts/worktrees.sh remove feature/foo`
+  - Clean stale refs (if needed): `scripts/worktrees.sh prune`
+
+Makefile Shortcuts
+- List: `make wt-list`
+- Create: `make wt-create BR=feature.foo [BASE=main]`
+- Add existing: `make wt-add BR=gh-pages`
+- Remove: `make wt-remove BR=feature.foo`
+- Path: `make wt-path BR=feature.foo`
+
+Working Guidelines
+- Always run Git commands inside the specific worktree directory you’re working in.
+- Push/pull as usual; new branches created via the script are based on `--base` (default `HEAD`).
+- If you need a long‑running local edit on `main`, do it at the repo root.
+- If two agents need similar work, create separate branches (e.g., `feature/foo-a`, `feature/foo-b`).
+
+Tips
+- To open multiple tabs quickly, use the printed path: `cd $(scripts/worktrees.sh path <branch>)`.
+- If a `remove` reports the worktree as "prunable", ensure no editor/process is locking the directory, then run `scripts/worktrees.sh prune`.
+- You can safely delete an untracked worktree directory if Git shows it as prunable; prefer the script to keep metadata tidy.
+
+Optional
+- To mirror all non-`main` branches as worktrees: for b in $(git for-each-ref --format='%(refname:short)' refs/heads | grep -v '^main$'); do scripts/worktrees.sh add "$b"; done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+# Worktree shortcuts
+# Usage examples:
+#   make wt-list
+#   make wt-create BR=feature.foo [BASE=main]
+#   make wt-add BR=gh-pages
+#   make wt-remove BR=feature.foo
+#   make wt-path BR=gh-pages
+
+SHELL := /bin/bash
+BASE ?= main
+
+.PHONY: wt-list wt-add wt-create wt-remove wt-prune wt-path
+
+wt-list:
+	./scripts/worktrees.sh list
+
+wt-add:
+	@test -n "$(BR)" || (echo "BR is required (branch name)" >&2; exit 1)
+	./scripts/worktrees.sh add "$(BR)"
+
+wt-create:
+	@test -n "$(BR)" || (echo "BR is required (branch name)" >&2; exit 1)
+	./scripts/worktrees.sh create "$(BR)" --base "$(BASE)"
+
+wt-remove:
+	@test -n "$(BR)" || (echo "BR is required (branch name)" >&2; exit 1)
+	./scripts/worktrees.sh remove "$(BR)"
+
+wt-prune:
+	./scripts/worktrees.sh prune
+
+wt-path:
+	@test -n "$(BR)" || (echo "BR is required (branch name)" >&2; exit 1)
+	./scripts/worktrees.sh path "$(BR)"
+

--- a/scripts/worktrees.sh
+++ b/scripts/worktrees.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# git worktree helper for repo-local worktrees under ./.worktrees
+#
+# Commands:
+#   list                          List configured worktrees
+#   add <branch>                  Add worktree for existing branch
+#   create <branch> [--base REF]  Create new branch from REF (default HEAD) and add worktree
+#   remove <branch>               Remove worktree for branch
+#   prune                         Prune stale worktree references
+#   path <branch>                 Print filesystem path for the worktree
+#
+# Examples:
+#   scripts/worktrees.sh list
+#   scripts/worktrees.sh add gh-pages
+#   scripts/worktrees.sh create feature/foo --base main
+#   scripts/worktrees.sh remove gh-pages
+
+usage() {
+  sed -n '1,40p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+require_repo_root() {
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Error: not inside a git repository" >&2
+    exit 1
+  fi
+}
+
+to_dir_name() {
+  # Map a branch like "feature/foo" to a safe dir name "feature-foo"
+  echo "$1" | sed 's#[/:]#-#g'
+}
+
+wt_dir_for_branch() {
+  local branch="$1"
+  local root
+  root="$(git rev-parse --show-toplevel)"
+  echo "$root/.worktrees/$(to_dir_name "$branch")"
+}
+
+ensure_wt_root() {
+  local root
+  root="$(git rev-parse --show-toplevel)"
+  mkdir -p "$root/.worktrees"
+}
+
+branch_exists() {
+  git show-ref --verify --quiet "refs/heads/$1"
+}
+
+cmd_list() {
+  git worktree list
+}
+
+cmd_add() {
+  local branch="$1"
+  ensure_wt_root
+  if ! branch_exists "$branch"; then
+    echo "Error: branch '$branch' does not exist. Use 'create' to create it." >&2
+    exit 1
+  fi
+
+  local dir
+  dir="$(wt_dir_for_branch "$branch")"
+  if [ -d "$dir" ]; then
+    echo "Skip: $dir already exists" >&2
+  else
+    git worktree add "$dir" "$branch"
+  fi
+}
+
+cmd_create() {
+  local branch="$1"; shift
+  local base="HEAD"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --base)
+        base="${2:-}"
+        if [ -z "$base" ]; then
+          echo "Error: --base requires a value" >&2
+          exit 1
+        fi
+        shift 2 ;;
+      *)
+        echo "Unknown option: $1" >&2
+        exit 1 ;;
+    esac
+  done
+
+  ensure_wt_root
+  local dir
+  dir="$(wt_dir_for_branch "$branch")"
+  if [ -d "$dir" ]; then
+    echo "Skip: $dir already exists" >&2
+  else
+    git worktree add -b "$branch" "$dir" "$base"
+  fi
+}
+
+cmd_remove() {
+  local branch="$1"
+  local dir
+  dir="$(wt_dir_for_branch "$branch")"
+  if [ ! -d "$dir" ]; then
+    echo "Skip: $dir not found" >&2
+  else
+    git worktree remove "$dir"
+  fi
+}
+
+cmd_prune() {
+  git worktree prune
+}
+
+cmd_path() {
+  wt_dir_for_branch "$1"
+}
+
+main() {
+  require_repo_root
+  local cmd="${1:-}"
+  case "$cmd" in
+    list)
+      shift; cmd_list "$@" ;;
+    add)
+      shift; [ $# -ge 1 ] || { echo "Usage: $0 add <branch>" >&2; exit 1; }
+      cmd_add "$1" ;;
+    create)
+      shift; [ $# -ge 1 ] || { echo "Usage: $0 create <branch> [--base REF]" >&2; exit 1; }
+      local branch="$1"; shift; cmd_create "$branch" "$@" ;;
+    remove)
+      shift; [ $# -ge 1 ] || { echo "Usage: $0 remove <branch>" >&2; exit 1; }
+      cmd_remove "$1" ;;
+    prune)
+      shift; cmd_prune ;;
+    path)
+      shift; [ $# -ge 1 ] || { echo "Usage: $0 path <branch>" >&2; exit 1; }
+      cmd_path "$1" ;;
+    -h|--help|help|"")
+      usage ;;
+    *)
+      echo "Unknown command: $cmd" >&2
+      usage ;;
+  esac
+}
+
+main "$@"
+


### PR DESCRIPTION
Keeps main at root; adds .worktrees management script, Makefile targets, and AGENTS.md.